### PR TITLE
Adding /var/tmp directory creation

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x \
  && chmod +x composer_install.sh \
  && ./composer_install.sh \
  && mv composer.phar /usr/local/bin/composer
+ && mkdir -p /var/tmp
 
 EXPOSE 80
 


### PR DESCRIPTION
Making sure the /var/tmp directory exists, as it's essential for apache2 to function.